### PR TITLE
Remove silent error consumption in getStringValue(...)

### DIFF
--- a/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/util/PropertyUtils.java
+++ b/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/util/PropertyUtils.java
@@ -213,12 +213,8 @@ public class PropertyUtils {
 	 *             value.
 	 */
 	public static String getStringValue(final NamedElement ph, final Property pd) {
-		try {
-			final PropertyExpression pv = getSimplePropertyValue(ph, pd);
-			return ((StringLiteral) pv).getValue();
-		} catch (PropertyLookupException e) {
-			return "";
-		}
+		final PropertyExpression pv = getSimplePropertyValue(ph, pd);
+		return ((StringLiteral) pv).getValue();
 	}
 
 	public static PropertyExpression getRecordFieldValue(final RecordValue rv, final String fieldName) {


### PR DESCRIPTION
The ```getStringValue``` method in the PropertyUtils class fails silently, instead of throwing any exceptions that get raised. This fix resolves that.

