### PR TITLE
fix for end to enc flow validation issue #763

### DIFF
--- a/org.osate.aadl2/src/org/osate/aadl2/instance/impl/ConnectionInstanceImpl.java
+++ b/org.osate.aadl2/src/org/osate/aadl2/instance/impl/ConnectionInstanceImpl.java
@@ -924,10 +924,10 @@ public class ConnectionInstanceImpl extends FlowElementInstanceImpl implements C
 	@Override
 	public boolean isActive(SystemOperationMode som) {
 		if (getInSystemOperationModes().isEmpty() || getInSystemOperationModes().contains(som)) {
-			return getContainingComponentInstance().isActive(som);
-		}
-		if (getSource().getComponentInstance().isActive(som) && getDestination().getComponentInstance().isActive(som)) {
-			return true;
+			if (getSource().getComponentInstance().isActive(som)
+					&& getDestination().getComponentInstance().isActive(som)) {
+				return getContainingComponentInstance().isActive(som);
+			}
 		}
 		return false;
 	}

--- a/org.osate.aadl2/src/org/osate/aadl2/instance/impl/ConnectionInstanceImpl.java
+++ b/org.osate.aadl2/src/org/osate/aadl2/instance/impl/ConnectionInstanceImpl.java
@@ -926,6 +926,9 @@ public class ConnectionInstanceImpl extends FlowElementInstanceImpl implements C
 		if (getInSystemOperationModes().isEmpty() || getInSystemOperationModes().contains(som)) {
 			return getContainingComponentInstance().isActive(som);
 		}
+		if (getSource().getComponentInstance().isActive(som) && getDestination().getComponentInstance().isActive(som)) {
+			return true;
+		}
 		return false;
 	}
 

--- a/org.osate.aadl2/src/org/osate/aadl2/instance/util/InstanceUtil.java
+++ b/org.osate.aadl2/src/org/osate/aadl2/instance/util/InstanceUtil.java
@@ -37,6 +37,7 @@
  */
 package org.osate.aadl2.instance.util;
 
+import java.util.Collection;
 import java.util.HashMap;
 
 import org.eclipse.emf.common.util.BasicEList;
@@ -64,6 +65,7 @@ import org.osate.aadl2.instance.ComponentInstance;
 import org.osate.aadl2.instance.FeatureCategory;
 import org.osate.aadl2.instance.FeatureInstance;
 import org.osate.aadl2.instance.InstanceObject;
+import org.osate.aadl2.instance.ModeInstance;
 import org.osate.aadl2.instance.SystemInstance;
 import org.osate.aadl2.instance.SystemOperationMode;
 
@@ -452,6 +454,25 @@ public class InstanceUtil {
 
 	public static boolean isNoMode(SystemOperationMode som) {
 		return som.getName().equalsIgnoreCase(NORMAL_SOM_NAME) || som.getName().equalsIgnoreCase("NoModes");
+	}
+
+	public static boolean isInMode(ComponentInstance ci, SystemOperationMode som) {
+		ComponentInstance modal = ci;
+		if (som == null || isNoMode(som))
+			return true;
+		Collection<ModeInstance> inModes = ci.getInModes();
+		while (inModes.isEmpty() && modal.getContainingComponentInstance() != null) {
+			modal = modal.getContainingComponentInstance();
+			inModes = modal.getInModes();
+		}
+		if (inModes.isEmpty())
+			return true;
+		for (ModeInstance mi : som.getCurrentModes()) {
+			if (inModes.contains(mi)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 }

--- a/org.osate.aadl2/src/org/osate/aadl2/instance/util/InstanceUtil.java
+++ b/org.osate.aadl2/src/org/osate/aadl2/instance/util/InstanceUtil.java
@@ -37,7 +37,6 @@
  */
 package org.osate.aadl2.instance.util;
 
-import java.util.Collection;
 import java.util.HashMap;
 
 import org.eclipse.emf.common.util.BasicEList;
@@ -65,7 +64,6 @@ import org.osate.aadl2.instance.ComponentInstance;
 import org.osate.aadl2.instance.FeatureCategory;
 import org.osate.aadl2.instance.FeatureInstance;
 import org.osate.aadl2.instance.InstanceObject;
-import org.osate.aadl2.instance.ModeInstance;
 import org.osate.aadl2.instance.SystemInstance;
 import org.osate.aadl2.instance.SystemOperationMode;
 
@@ -455,24 +453,4 @@ public class InstanceUtil {
 	public static boolean isNoMode(SystemOperationMode som) {
 		return som.getName().equalsIgnoreCase(NORMAL_SOM_NAME) || som.getName().equalsIgnoreCase("NoModes");
 	}
-
-	public static boolean isInMode(ComponentInstance ci, SystemOperationMode som) {
-		ComponentInstance modal = ci;
-		if (som == null || isNoMode(som))
-			return true;
-		Collection<ModeInstance> inModes = ci.getInModes();
-		while (inModes.isEmpty() && modal.getContainingComponentInstance() != null) {
-			modal = modal.getContainingComponentInstance();
-			inModes = modal.getInModes();
-		}
-		if (inModes.isEmpty())
-			return true;
-		for (ModeInstance mi : som.getCurrentModes()) {
-			if (inModes.contains(mi)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
 }

--- a/org.osate.aadl2/src/org/osate/aadl2/util/Aadl2Util.java
+++ b/org.osate.aadl2/src/org/osate/aadl2/util/Aadl2Util.java
@@ -184,7 +184,7 @@ public class Aadl2Util {
 		if (som == null || InstanceUtil.isNoMode(som)) {
 			return "";
 		}
-		return "In SystemMode " + som.getName() + ": ";
+		return "In SystemMode " + som.getName();
 	}
 
 	public static boolean isPrintableSOMName(SystemOperationMode som) {

--- a/org.osate.core.tests/src/org/osate/core/tests/aadl2javavalidator/EndToEndFlowSegmentTypesTest.xtend
+++ b/org.osate.core.tests/src/org/osate/core/tests/aadl2javavalidator/EndToEndFlowSegmentTypesTest.xtend
@@ -317,6 +317,11 @@ class EndToEndFlowSegmentTypesTest extends OsateTest {
 						//Tests typeCheckEndToEndFlowSegments
 						assertError(testFileResult.issues, issueCollection, "Anything in a 'data port' is not a valid subcomponent flow.")
 					]
+					ownedEndToEndFlowSegments.get(1) => [
+						"fconn1".assertEquals(flowElement.name)
+						//connection end does not match
+						assertError(testFileResult.issues, issueCollection, "The source of connection 'fconn1' does not match the preceding subcomponent or out flow spec feature 'dp1.af3'")
+					]
 				]
 				ownedEndToEndFlows.get(15) => [
 					"etef16".assertEquals(name)
@@ -325,6 +330,11 @@ class EndToEndFlowSegmentTypesTest extends OsateTest {
 						"asub3".assertEquals(flowElement.name)
 						//Tests typeCheckEndToEndFlowSegments
 						assertError(testFileResult.issues, issueCollection, "Anything in a 'data port' is not a valid subcomponent flow.")
+					]
+					ownedEndToEndFlowSegments.get(1) => [
+						"fconn1".assertEquals(flowElement.name)
+						//connection end does not match
+						assertError(testFileResult.issues, issueCollection, "The source of connection 'fconn1' does not match the preceding subcomponent or out flow spec feature 'asub3'")
 					]
 				]
 				ownedEndToEndFlows.get(16) => [
@@ -362,6 +372,11 @@ class EndToEndFlowSegmentTypesTest extends OsateTest {
 						//Tests typeCheckEndToEndFlowSegments
 						assertError(testFileResult.issues, issueCollection, "Anything in an 'event data port' is not a valid subcomponent flow.")
 					]
+					ownedEndToEndFlowSegments.get(1) => [
+						"fconn1".assertEquals(flowElement.name)
+						//connection end does not match
+						assertError(testFileResult.issues, issueCollection, "The source of connection 'fconn1' does not match the preceding subcomponent or out flow spec feature 'edp1.af3'")
+					]
 				]
 				ownedEndToEndFlows.get(20) => [
 					"etef21".assertEquals(name)
@@ -370,6 +385,11 @@ class EndToEndFlowSegmentTypesTest extends OsateTest {
 						"asub3".assertEquals(flowElement.name)
 						//Tests typeCheckEndToEndFlowSegments
 						assertError(testFileResult.issues, issueCollection, "Anything in an 'event data port' is not a valid subcomponent flow.")
+					]
+					ownedEndToEndFlowSegments.get(1) => [
+						"fconn1".assertEquals(flowElement.name)
+						//connection end does not match
+						assertError(testFileResult.issues, issueCollection, "The source of connection 'fconn1' does not match the preceding subcomponent or out flow spec feature 'asub3'")
 					]
 				]
 				ownedEndToEndFlows.get(21) => [
@@ -416,6 +436,11 @@ class EndToEndFlowSegmentTypesTest extends OsateTest {
 						//Tests typeCheckEndToEndFlowSegments
 						assertError(testFileResult.issues, issueCollection, "An 'abstract subcomponent' in an 'abstract subcomponent' is not a valid subcomponent flow.")
 					]
+					ownedEndToEndFlowSegments.get(1) => [
+						"fconn1".assertEquals(flowElement.name)
+						//connection end does not match
+						assertError(testFileResult.issues, issueCollection, "The source of connection 'fconn1' does not match the preceding subcomponent or out flow spec feature 'asub2'")
+					]
 				]
 				ownedEndToEndFlows.get(27) => [
 					"etef28".assertEquals(name)
@@ -452,6 +477,11 @@ class EndToEndFlowSegmentTypesTest extends OsateTest {
 						//Tests typeCheckEndToEndFlowSegments
 						assertError(testFileResult.issues, issueCollection, "Anything in a 'subprogram call' is not a valid subcomponent flow.")
 					]
+					ownedEndToEndFlowSegments.get(1) => [
+						"fconn1".assertEquals(flowElement.name)
+						//connection end does not match
+						assertError(testFileResult.issues, issueCollection, "The source of connection 'fconn1' does not match the preceding subcomponent or out flow spec feature 'call1.af4'")
+					]
 				]
 				ownedEndToEndFlows.get(31) => [
 					"etef32".assertEquals(name)
@@ -460,6 +490,11 @@ class EndToEndFlowSegmentTypesTest extends OsateTest {
 						"asub4".assertEquals(flowElement.name)
 						//Tests typeCheckEndToEndFlowSegments
 						assertError(testFileResult.issues, issueCollection, "Anything in a 'subprogram call' is not a valid subcomponent flow.")
+					]
+					ownedEndToEndFlowSegments.get(1) => [
+						"fconn1".assertEquals(flowElement.name)
+						//connection end does not match
+						assertError(testFileResult.issues, issueCollection, "The source of connection 'fconn1' does not match the preceding subcomponent or out flow spec feature 'asub4'")
 					]
 				]
 			]
@@ -508,6 +543,11 @@ class EndToEndFlowSegmentTypesTest extends OsateTest {
 						"asub3".assertEquals(flowElement.name)
 						//Tests typeCheckEndToEndFlowSegments
 						assertError(testFileResult.issues, issueCollection, "Anything in a 'parameter' is not a valid subcomponent flow.")
+					]
+					ownedEndToEndFlowSegments.get(1) => [
+						"fconn4".assertEquals(flowElement.name)
+						//connection end does not match
+						assertError(testFileResult.issues, issueCollection, "The source of connection 'fconn4' does not match the preceding subcomponent or out flow spec feature 'asub3'")
 					]
 				]
 			]

--- a/org.osate.ui/src/org/osate/ui/actions/AbstractInstanceOrDeclarativeModelReadOnlyAction.java
+++ b/org.osate.ui/src/org/osate/ui/actions/AbstractInstanceOrDeclarativeModelReadOnlyAction.java
@@ -141,7 +141,7 @@ public abstract class AbstractInstanceOrDeclarativeModelReadOnlyAction extends A
 
 	private void analyzeInstanceModelInMode(final IProgressMonitor monitor,
 			final AnalysisErrorReporterManager errManager, final SystemInstance si, final SystemOperationMode som) {
-		errManager.addPrefix(Aadl2Util.getPrintableSOMName(som));
+		errManager.addPrefix(Aadl2Util.getPrintableSOMName(som) + ": ");
 		analyzeInstanceModel(monitor, errManager, si, som);
 		si.clearCurrentSystemOperationMode();
 		errManager.removePrefix();

--- a/org.osate.workspace/resources/properties/Predeclared_Property_Sets/AADL_Project.aadl
+++ b/org.osate.workspace/resources/properties/Predeclared_Property_Sets/AADL_Project.aadl
@@ -76,9 +76,9 @@ property set AADL_Project is
 	
 	Time_Units: type units (ps, ns => ps * 1000, us => ns * 1000, ms => us * 1000, sec => ms * 1000, min => sec * 60, hr => min * 60);
 
-	Data_Rate_Units: type	units (bitsps, Bytesps => bitsps * 8, KBytesps => Bytesps * 1000, MBytesps => KBytesps * 1000, GBytesps => MBytesps * 1000);
+	Data_Rate_Units: type units (bitsps, Bytesps => bitsps * 8, Kbitsps => Bytesps * 125,KBytesps => Kbitsps * 8, Mbitsps => KBytesps * 125,MBytesps => Mbitsps * 8, Gbitsps => MBytesps * 125,GBytesps => Gbitsps * 8);
 
-	Data_Volume_Units: type	units (bitsps, Bytesps => bitsps * 8, KBytesps => Bytesps * 1000, MBytesps => KBytesps * 1000, GBytesps => MBytesps * 1000);
+	Data_Volume_Units: type units (bitsps, Bytesps => bitsps * 8, Kbitsps => Bytesps * 125,KBytesps => Kbitsps * 8, Mbitsps => KBytesps * 125,MBytesps => Mbitsps * 8, Gbitsps => MBytesps * 125,GBytesps => Gbitsps * 8);
 	Max_Volume: constant Data_Volume => 1000 GBytesps;
 
 	Data_Volume: type aadlinteger 0 bitsps .. Max_Volume units Data_Volume_Units;

--- a/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/util/AadlProject.java
+++ b/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/util/AadlProject.java
@@ -121,10 +121,9 @@ public final class AadlProject {
 //
 //	public static final String DATA_VOLUME_UNITS = "Data_Volume_Units";
 	public static final String BITSPS_LITERAL = "bitsps";
-	public static final String BPS_LITERAL = "Bytesps";
-	public static final String KBPS_LITERAL = "KBytesps";
-	public static final String MBPS_LITERAL = "MBytesps";
-	public static final String GBPS_LITERAL = "GBytesps";
+	public static final String KBITSPS_LITERAL = "Kbitsps";
+	public static final String MBITSPS_LITERAL = "Mbitsps";
+	public static final String GBITSPS_LITERAL = "Gbitsps";
 	public static final String BYTESPS_LITERAL = "Bytesps";
 	public static final String KBYTESPS_LITERAL = "KBytesps";
 	public static final String MBYTESPS_LITERAL = "MBytesps";

--- a/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/util/GetProperties.java
+++ b/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/util/GetProperties.java
@@ -340,6 +340,10 @@ public class GetProperties {
 		return findUnitLiteral(context, AadlProject.DATA_RATE_UNITS, AadlProject.KBYTESPS_LITERAL);
 	}
 
+	public static UnitLiteral getKbitspsUnitLiteral(NamedElement context) {
+		return findUnitLiteral(context, AadlProject.DATA_RATE_UNITS, AadlProject.KBITSPS_LITERAL);
+	}
+
 	public static UnitLiteral getKBUnitLiteral(NamedElement context) {
 		return findUnitLiteral(context, AadlProject.SIZE_UNITS, AadlProject.KB_LITERAL);
 	}
@@ -549,15 +553,27 @@ public class GetProperties {
 		return PropertyUtils.getScaledNumberValue(ne, ROMActual, kb, defaultValue);
 	}
 
-	public static double getBandWidthCapacityInKbps(final NamedElement ne, final double defaultValue) {
+	public static double getBandWidthCapacityInKBytesps(final NamedElement ne, final double defaultValue) {
 		Property BandWidthCapacity = lookupPropertyDefinition(ne, SEI._NAME, SEI.BANDWIDTH_CAPACITY);
 		UnitLiteral Kbps = findUnitLiteral(BandWidthCapacity, AadlProject.KBYTESPS_LITERAL);
 		return PropertyUtils.getScaledNumberValue(ne, BandWidthCapacity, Kbps, defaultValue);
 	}
 
-	public static double getBandWidthBudgetInKbps(final NamedElement ne, final double defaultValue) {
+	public static double getBandWidthBudgetInKBytesps(final NamedElement ne, final double defaultValue) {
 		Property BandWidthBudget = lookupPropertyDefinition(ne, SEI._NAME, SEI.BANDWIDTH_BUDGET);
 		UnitLiteral Kbps = findUnitLiteral(BandWidthBudget, AadlProject.KBYTESPS_LITERAL);
+		return PropertyUtils.getScaledNumberValue(ne, BandWidthBudget, Kbps, defaultValue);
+	}
+
+	public static double getBandWidthCapacityInKbitsps(final NamedElement ne, final double defaultValue) {
+		Property BandWidthCapacity = lookupPropertyDefinition(ne, SEI._NAME, SEI.BANDWIDTH_CAPACITY);
+		UnitLiteral Kbps = findUnitLiteral(BandWidthCapacity, AadlProject.KBITSPS_LITERAL);
+		return PropertyUtils.getScaledNumberValue(ne, BandWidthCapacity, Kbps, defaultValue);
+	}
+
+	public static double getBandWidthBudgetInKbitsps(final NamedElement ne, final double defaultValue) {
+		Property BandWidthBudget = lookupPropertyDefinition(ne, SEI._NAME, SEI.BANDWIDTH_BUDGET);
+		UnitLiteral Kbps = findUnitLiteral(BandWidthBudget, AadlProject.KBITSPS_LITERAL);
 		return PropertyUtils.getScaledNumberValue(ne, BandWidthBudget, Kbps, defaultValue);
 	}
 

--- a/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/validation/Aadl2JavaValidator.java
+++ b/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/validation/Aadl2JavaValidator.java
@@ -2229,43 +2229,84 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 						.getFlowElement() instanceof FlowSpecification) {
 					FlowSpecification previousFlowSegment = (FlowSpecification) flow.getOwnedEndToEndFlowSegments()
 							.get(i - 1).getFlowElement();
+					Context previousFlowCxt = flow.getOwnedEndToEndFlowSegments().get(i - 1).getContext();
 					FlowEnd outEnd = previousFlowSegment.getAllOutEnd();
 					if (Aadl2Util.isNull(outEnd)) {
 						return;
 					}
-					if (!isMatchingConnectionPoint(outEnd.getFeature(), outEnd.getContext(), ce, cxt)) {
+					Boolean noMatch = false;
+					if (isMatchingConnectionPoint(outEnd.getFeature(), outEnd.getContext(), ce, cxt)) {
+						if (cxt instanceof Subcomponent && previousFlowCxt instanceof Subcomponent) {
+							if (!(AadlUtil.isSameOrRefines((Subcomponent) cxt, (Subcomponent) previousFlowCxt)
+									|| AadlUtil.isSameOrRefines((Subcomponent) previousFlowCxt, (Subcomponent) cxt))) {
+								noMatch = true;
+							}
+						}
+					} else {
 						if (connection.isAllBidirectional()) {
 							ce = connection.getAllDestination();
 							cxt = connection.getAllDestinationContext();
-							if (!isMatchingConnectionPoint(outEnd.getFeature(), outEnd.getContext(), ce, cxt)) {
-								error(flow.getOwnedEndToEndFlowSegments().get(i),
-										"The source of connection '" + connection.getName()
-												+ "' does not match the out flow feature of the preceding subcomponent flow specification '"
-												+ flow.getOwnedEndToEndFlowSegments().get(i - 1).getContext().getName()
-												+ '.' + previousFlowSegment.getName() + '\'');
+							if (isMatchingConnectionPoint(outEnd.getFeature(), outEnd.getContext(), ce, cxt)) {
+								if (cxt instanceof Subcomponent && previousFlowCxt instanceof Subcomponent) {
+									if (!(AadlUtil.isSameOrRefines((Subcomponent) cxt, (Subcomponent) previousFlowCxt)
+											|| AadlUtil.isSameOrRefines((Subcomponent) previousFlowCxt,
+													(Subcomponent) cxt))) {
+										noMatch = true;
+									}
+								} else {
+									noMatch = true;
+								}
 							} else {
+								noMatch = true;
+							}
+							if (!noMatch) {
 								didReverse = true;
 							}
+						} else {
+							noMatch = true;
 						}
+					}
+					if (noMatch) {
+						error(flow.getOwnedEndToEndFlowSegments().get(i),
+								"The source of connection '" + connection.getName()
+										+ "' does not match the preceding subcomponent or out flow spec feature '"
+										+ flow.getOwnedEndToEndFlowSegments().get(i - 1).getContext().getName() + '.'
+										+ outEnd.getFeature().getName() + '\'');
 					}
 				} else if (i > 0
 						&& flow.getOwnedEndToEndFlowSegments().get(i - 1).getFlowElement() instanceof Subcomponent) {
 					Subcomponent previousFlowSegment = (Subcomponent) flow.getOwnedEndToEndFlowSegments().get(i - 1)
 							.getFlowElement();
-					if (connection.isAllBidirectional()) {
-						ce = connection.getAllSource();
-						cxt = connection.getAllSourceContext();
-						if (cxt == null && !ce.equals(previousFlowSegment)) {
-							error(flow.getOwnedEndToEndFlowSegments().get(i),
-									"The source of connection '" + connection.getName()
-											+ "' does not match the out flow feature of the preceding subcomponent '"
-											+ previousFlowSegment.getName() + '\'');
-							didReverse = true;
-						} else {
-							didReverse = false;
+					Boolean noMatch = false;
+					if (cxt instanceof Subcomponent) {
+						if (!(AadlUtil.isSameOrRefines((Subcomponent) cxt, previousFlowSegment)
+								|| AadlUtil.isSameOrRefines(previousFlowSegment, (Subcomponent) cxt))) {
+							if (connection.isAllBidirectional()) {
+								ce = connection.getAllSource();
+								cxt = connection.getAllSourceContext();
+								if (cxt instanceof Subcomponent) {
+									if (!(AadlUtil.isSameOrRefines((Subcomponent) cxt, previousFlowSegment)
+											|| AadlUtil.isSameOrRefines(previousFlowSegment, (Subcomponent) cxt))) {
+										noMatch = true;
+									} else {
+										didReverse = true;
+									}
+								} else {
+									noMatch = true;
+								}
+							} else {
+								noMatch = true;
+							}
 						}
+					} else {
+						noMatch = true;
 					}
-
+					if (noMatch) {
+						error(flow.getOwnedEndToEndFlowSegments().get(i),
+								"The source of connection '" + connection.getName()
+										+ "' does not match the preceding subcomponent or out flow spec feature '"
+										+ previousFlowSegment.getName() + '\'');
+					}
 				}
 				if (didReverse) {
 					ce = connection.getAllSource();
@@ -2276,33 +2317,58 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 				}
 				if (i + 1 < size) {
 					EndToEndFlowElement felem = flow.getOwnedEndToEndFlowSegments().get(i + 1).getFlowElement();
+					Context nextFlowCxt = flow.getOwnedEndToEndFlowSegments().get(i + 1).getContext();
 					if (felem instanceof FlowSpecification) {
 						FlowSpecification nextFlowSegment = (FlowSpecification) felem;
 						FlowEnd inEnd = nextFlowSegment.getAllInEnd();
 						if (Aadl2Util.isNull(inEnd)) {
 							return;
 						}
+						Boolean noMatch = false;
 						if (ce instanceof Feature) {
-							if (!isMatchingConnectionPoint(inEnd.getFeature(), inEnd.getContext(), ce, cxt)) {
-								error(flow.getOwnedEndToEndFlowSegments().get(i),
-										"The destination of connection '" + connection.getName()
-												+ "' does not match the in flow feature of the succeeding subcomponent flow specification '"
-												+ flow.getOwnedEndToEndFlowSegments().get(i + 1).getContext().getName()
-												+ '.' + nextFlowSegment.getName() + '\'');
+							if (isMatchingConnectionPoint(inEnd.getFeature(), inEnd.getContext(), ce, cxt)) {
+								if (cxt instanceof Subcomponent && nextFlowCxt instanceof Subcomponent) {
+									if (!(AadlUtil.isSameOrRefines((Subcomponent) cxt, nextFlowSegment)
+											|| AadlUtil.isSameOrRefines(nextFlowSegment, (Subcomponent) cxt))) {
+									}
+								} else {
+									noMatch = true;
+								}
+							} else {
+								noMatch = true;
 							}
+						} else {
+							noMatch = true;
+						}
+						if (noMatch) {
+							error(flow.getOwnedEndToEndFlowSegments().get(i),
+									"The destination of connection '" + connection.getName()
+											+ "' does not match the succeeding subcomponent or in flow spec feature '"
+											+ flow.getOwnedEndToEndFlowSegments().get(i + 1).getContext().getName()
+											+ '.' + inEnd.getFeature().getName() + '\'');
 						}
 					} else if (felem instanceof Subcomponent) {
 						Subcomponent nextFlowSegment = (Subcomponent) felem;
-						if (cxt == null && !ce.equals(nextFlowSegment)) {
+						Boolean noMatch = false;
+						if (cxt instanceof Subcomponent) {
+							if (!(AadlUtil.isSameOrRefines((Subcomponent) cxt, nextFlowSegment)
+									|| AadlUtil.isSameOrRefines(nextFlowSegment, (Subcomponent) cxt))) {
+								noMatch = true;
+							}
+						} else {
+							noMatch = true;
+						}
+						if (noMatch) {
 							error(flow.getOwnedEndToEndFlowSegments().get(i),
 									"The destination of connection '" + connection.getName()
-											+ "' does not match the out flow feature of the succeeding subcomponent '"
+											+ "' does not match the succeeding subcomponent or in flow spec feature '"
 											+ nextFlowSegment.getName() + '\'');
 						}
 					}
 				}
 			}
 		}
+
 	}
 
 	/**
@@ -7481,10 +7547,10 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 					// + " must not be " + notDir.getName() + " due to the
 					// direction of the connection", conn,
 					// structuralFeature);
-					error("Feature " + feature.getName() + " in the referenced feature group " + (sub == null ? ""
-							: (sub.getName() + ".")) + featureGroup.getName() + " must not be " + notDir.getName()
-									+ " due to the direction of the connection",
-							conn, structuralFeature, MAKE_CONNECTION_BIDIRECTIONAL);
+					error("Feature " + feature.getName() + " in the referenced feature group "
+							+ (sub == null ? "" : (sub.getName() + ".")) + featureGroup.getName() + " must not be "
+							+ notDir.getName() + " due to the direction of the connection", conn, structuralFeature,
+							MAKE_CONNECTION_BIDIRECTIONAL);
 
 				}
 			}
@@ -7573,7 +7639,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 										&& destinationDirection == DirectionType.IN_OUT
 										&& sourceFeature instanceof Access)) {
 									error(connection,
-											"The the source feature group access feature '" + source.getName() + "."
+											"The source feature group access feature '" + source.getName() + "."
 													+ sourceFeature.getName()
 													+ "' cannot be connected to destination feature group directional feature '"
 													+ destination.getName() + "." + destinationFeature.getName());
@@ -7631,8 +7697,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 								if (!(sourceFeature instanceof AbstractFeature
 										&& ((AbstractFeature) sourceFeature).getDirection() == DirectionType.IN_OUT)) {
 									error(connection,
-											"The the source feature group directional feature '" + source.getName()
-													+ "." + sourceFeature.getName()
+											"The source feature group directional feature '" + source.getName() + "."
+													+ sourceFeature.getName()
 													+ "' cannot be connected to destination feature group access feature '"
 													+ destination.getName() + "." + destinationFeature.getName());
 								}


### PR DESCRIPTION
fixes #763
end to end flow now checks that both the feature and the subcomponent as
endpoints of a connection in a flow are consistent with the port and
subcomponent of the predecessor and successor in the end to end flow.
Required updates to the test suite.