### PR TITLE
Visibility tweaks so subclasses of the instantiator can make changes

### DIFF
--- a/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -156,7 +156,7 @@ public class InstantiateModel {
 	 * feature or subprogram call. If the classifier is anonymous, then its
 	 * bindings are included also.
 	 */
-	private HashMap<InstanceObject, InstantiatedClassifier> classifierCache;
+	protected HashMap<InstanceObject, InstantiatedClassifier> classifierCache;
 
 	private SCProperties scProps = new SCProperties();
 	/**

--- a/org.osate.aadl2/src/org/osate/aadl2/instance/util/InstanceUtil.java
+++ b/org.osate.aadl2/src/org/osate/aadl2/instance/util/InstanceUtil.java
@@ -89,7 +89,7 @@ public class InstanceUtil {
 		InstantiatedClassifier() {
 		}
 
-		InstantiatedClassifier(Classifier classifier, EList<PrototypeBinding> bindings) {
+		public InstantiatedClassifier(Classifier classifier, EList<PrototypeBinding> bindings) {
 			this.classifier = classifier;
 			this.bindings = bindings;
 		}


### PR DESCRIPTION
The GTSE work extends the instantiator and needs access to a couple of things that previously had either private or default visibility.