### PR TITLE
Keep removal of markers in the caller's thread 

### DIFF
--- a/org.osate.aadl2.modelsupport/src/org/osate/aadl2/modelsupport/errorreporting/MarkerParseErrorReporter.java
+++ b/org.osate.aadl2.modelsupport/src/org/osate/aadl2/modelsupport/errorreporting/MarkerParseErrorReporter.java
@@ -36,10 +36,6 @@ package org.osate.aadl2.modelsupport.errorreporting;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.osate.aadl2.modelsupport.Activator;
 
@@ -117,18 +113,11 @@ public final class MarkerParseErrorReporter extends AbstractParseErrorReporter {
 	@Override
 	protected void deleteMessagesImpl() {
 		if (resource.exists()) {
-			Job deleteMarkerJob = new Job("DeleteMarkersJob") {
-				@Override
-				protected IStatus run(IProgressMonitor monitor) {
-					try {
-						resource.deleteMarkers(markerType, false, IResource.DEPTH_INFINITE);
-					} catch (final CoreException e1) {
-						Activator.logThrowable(e1);
-					}
-					return Status.OK_STATUS;
-				}
-			};
-			deleteMarkerJob.schedule();
+			try {
+				resource.deleteMarkers(markerType, false, IResource.DEPTH_INFINITE);
+			} catch (final CoreException e1) {
+				Activator.logThrowable(e1);
+			}
 		}
 	}
 


### PR DESCRIPTION
This change appears to avoid race conditions in creation/deletion of markers, specifically issue https://github.com/osate/osate2-core/issues/891