### PR TITLE
Fixes osate/osate2-core#931

### DIFF
--- a/org.osate.core.tests/models/issue931/.gitignore
+++ b/org.osate.core.tests/models/issue931/.gitignore
@@ -1,0 +1,1 @@
+/.aadlbin-gen/

--- a/org.osate.core.tests/models/issue931/.project
+++ b/org.osate.core.tests/models/issue931/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue931</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/org.osate.core.tests/models/issue931/issue931.aadl
+++ b/org.osate.core.tests/models/issue931/issue931.aadl
@@ -1,0 +1,33 @@
+package issue931
+public
+	system s
+		features
+			inp: in data port;
+		flows
+			insink: flow sink inp;
+	end s;
+	
+	system se extends s
+		features
+			inp: refined to in data port d;
+	end se;
+	
+	system implementation se.i
+		subcomponents
+			sub1: system sub;
+		connections
+			c1: port inp -> sub1.inport;
+		flows
+			insink: flow sink inp -> c1 -> sub1.fsink;
+	end se.i;
+	
+	system sub
+		features
+			inport: in data port d;
+		flows
+			fsink: flow sink inport;
+	end sub;
+	data d
+		
+	end d;
+end issue931;

--- a/org.osate.core.tests/src/org/osate/core/tests/issues/Issue931Test.xtend
+++ b/org.osate.core.tests/src/org/osate/core/tests/issues/Issue931Test.xtend
@@ -1,0 +1,37 @@
+package org.osate.core.tests.issues
+
+import com.itemis.xtext.testing.FluentIssueCollection
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.osate.aadl2.AadlPackage
+import org.osate.aadl2.NamedElement
+import org.osate.core.test.Aadl2UiInjectorProvider
+import org.osate.core.test.OsateTest
+
+import static extension org.junit.Assert.assertEquals
+
+@RunWith(XtextRunner)
+@InjectWith(Aadl2UiInjectorProvider)
+class Issue931Test extends OsateTest {
+	val static PROJECT_LOCATION = "org.osate.core.tests/models/issue931/"
+
+	@Test
+	def void issue931() {
+		val pkg1FileName = "issue931.aadl"
+		createFiles(
+			pkg1FileName -> readFile(PROJECT_LOCATION + pkg1FileName)
+		)
+		suppressSerialization
+		val testFileResult = testFile(pkg1FileName)
+		val issueCollection = new FluentIssueCollection(testFileResult.resource, newArrayList, newArrayList)
+		issueCollection.isEmpty.assertEquals(true)
+		testFileResult.resource.contents.head as AadlPackage => [
+			"issue931".assertEquals(name)
+			publicSection.ownedClassifiers.get(0) as NamedElement => [
+				"s".assertEquals(name)
+			]
+		]
+	}
+}

--- a/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/validation/Aadl2JavaValidator.java
+++ b/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/validation/Aadl2JavaValidator.java
@@ -38,7 +38,6 @@ package org.osate.xtext.aadl2.validation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -874,7 +873,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 		} else {
 			if (isSubcomponentCircularDependency(subcomponentType, containingClassifier, new ArrayList<Classifier>())) {
 				error(subcomponent, "Invalid circular dependency. Subcomponent '" + subcomponent.getName()
-						+ "' directly or indirectly contains '" + containingClassifier.getName() + "'.");
+				+ "' directly or indirectly contains '" + containingClassifier.getName() + "'.");
 			}
 		}
 	}
@@ -1070,7 +1069,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 					for (Mode containerMode : allContainerModes) {
 						if (!modesForAllModalPropertyValues.contains(containerMode) && !defaultValue) {
 							warning(ownedPropertyAssociation, "Value not set for mode " + containerMode.getName()
-									+ " for property " + property.getQualifiedName());
+							+ " for property " + property.getQualifiedName());
 						}
 					}
 				}
@@ -1280,15 +1279,16 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 		boolean match;
 		if (specContext == null) {
 			if (implContext == null) {
-				match = specFeature == implFeature;
+				match = specFeature.getName().equalsIgnoreCase(implFeature.getName());
 			} else {
-				match = specFeature == implContext;
+				match = specFeature.getName().equalsIgnoreCase(implContext.getName());
 			}
 		} else {
 			if (implContext == null) {
 				match = false;
 			} else {
-				match = specContext == implContext && specFeature == implFeature;
+				match = specContext.getName().equalsIgnoreCase(implContext.getName())
+						&& specFeature.getName().equalsIgnoreCase(implFeature.getName());
 			}
 		}
 
@@ -1309,8 +1309,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 			if (implkind != speckind) {
 				String offSet = "" + findKeywordOffset(flowimpl, implkind.toString());
 				error("Flow implementation " + spec.getName() + " must be a flow " + speckind.getName()
-						+ " (same as its flow spec)", flowimpl, null, INCONSISTENT_FLOW_KIND, implkind.getName(),
-						speckind.getName(), offSet);
+				+ " (same as its flow spec)", flowimpl, null, INCONSISTENT_FLOW_KIND, implkind.getName(),
+				speckind.getName(), offSet);
 
 			}
 		}
@@ -1358,7 +1358,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 				connNext = !connNext;
 				if (!fe.eIsProxy() && (flowSegment.getContext() == null || !flowSegment.getContext().eIsProxy())
 						&& !((flowSegment.getContext() == null
-								&& (fe instanceof DataAccess || fe instanceof Subcomponent))
+						&& (fe instanceof DataAccess || fe instanceof Subcomponent))
 								|| (flowSegment.getContext() instanceof Subcomponent
 										&& fe instanceof FlowSpecification))) {
 					StringBuilder errorMessage = new StringBuilder(
@@ -1429,9 +1429,9 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 						if (noMatch) {
 							error(flow.getOwnedFlowSegments().get(i),
 									"The source of connection '" + connection.getName()
-											+ "' does not match the in flow feature '"
-											+ (inEnd.getContext() != null ? inEnd.getContext().getName() + '.' : "")
-											+ inEnd.getFeature().getName() + '\'');
+									+ "' does not match the in flow feature '"
+									+ (inEnd.getContext() != null ? inEnd.getContext().getName() + '.' : "")
+									+ inEnd.getFeature().getName() + '\'');
 						}
 					}
 				} else {
@@ -1459,17 +1459,17 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 							if (noMatch) {
 								error(flow.getOwnedFlowSegments().get(i),
 										"The source of connection '" + connection.getName()
-												+ "' does not match the out flow feature of the preceding subcomponent flow specification '"
-												+ flow.getOwnedFlowSegments().get(i - 1).getContext().getName() + '.'
-												+ previousFlowSegment.getName() + '\'');
+										+ "' does not match the out flow feature of the preceding subcomponent flow specification '"
+										+ flow.getOwnedFlowSegments().get(i - 1).getContext().getName() + '.'
+										+ previousFlowSegment.getName() + '\'');
 							}
 						}
 					} else if (prevFlowElement instanceof Subcomponent) {
 						if (prevFlowElement != cxt) {
 							error(flow.getOwnedFlowSegments().get(i),
 									"The source of connection '" + connection.getName()
-											+ "' does not match the preceding subcomponent '"
-											+ ((Subcomponent) prevFlowElement).getName() + '\'');
+									+ "' does not match the preceding subcomponent '"
+									+ ((Subcomponent) prevFlowElement).getName() + '\'');
 						}
 					}
 				}
@@ -1491,9 +1491,9 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 						if (!isMatchingConnectionPoint(outEnd.getFeature(), outEnd.getContext(), connectedElement)) {
 							error(flow.getOwnedFlowSegments().get(i),
 									"The destination of connection '" + connection.getName()
-											+ "' does not match the out flow feature '"
-											+ (outEnd.getContext() != null ? outEnd.getContext().getName() + '.' : "")
-											+ outEnd.getFeature().getName() + '\'');
+									+ "' does not match the out flow feature '"
+									+ (outEnd.getContext() != null ? outEnd.getContext().getName() + '.' : "")
+									+ outEnd.getFeature().getName() + '\'');
 						}
 					}
 				} else {
@@ -1508,9 +1508,9 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 							if (!isMatchingConnectionPoint(inEnd.getFeature(), inEnd.getContext(), connectedElement)) {
 								error(flow.getOwnedFlowSegments().get(i),
 										"The destination of connection '" + connection.getName()
-												+ "' does not match the in flow feature of the succeeding subcomponent flow specification '"
-												+ flow.getOwnedFlowSegments().get(i + 1).getContext().getName() + '.'
-												+ nextFlowSegment.getName() + '\'');
+										+ "' does not match the in flow feature of the succeeding subcomponent flow specification '"
+										+ flow.getOwnedFlowSegments().get(i + 1).getContext().getName() + '.'
+										+ nextFlowSegment.getName() + '\'');
 							}
 						}
 					} else if (felem instanceof Subcomponent) {
@@ -1603,7 +1603,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 				for (Connection innerConn : sub.getComponentImplementation().getAllConnections()) {
 					if ((innerConn.getAllSourceContext() == null && innerConn.getAllLastSource() == ce)
 							|| (innerConn.getAllDestinationContext() == null
-									&& innerConn.getAllLastDestination() == ce)) {
+							&& innerConn.getAllLastDestination() == ce)) {
 						// connection continues inside subcomponent
 						error(segment, "Connection '" + conn.getName() + "' continues inside subcomponent '"
 								+ sub.getName() + "'");
@@ -2157,8 +2157,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 						}
 					} else {
 						error("Anything in " + getEClassDisplayNameWithIndefiniteArticle(segment.getContext().eClass())
-								+ " is not a valid subcomponent flow.", segment,
-								Aadl2Package.eINSTANCE.getEndToEndFlowSegment_Context());
+						+ " is not a valid subcomponent flow.", segment,
+						Aadl2Package.eINSTANCE.getEndToEndFlowSegment_Context());
 					}
 				} else {
 					// Checking ETEConnectionFlow
@@ -2197,16 +2197,16 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 					if (((FlowSpecification) segment.getFlowElement()).getKind() == FlowKind.SINK) {
 						error(segment,
 								"Illegal reference to '" + segment.getContext().getName() + '.'
-										+ segment.getFlowElement().getName()
-										+ "'.  First segment of end-to-end flow cannot refer to a flow sink.");
+								+ segment.getFlowElement().getName()
+								+ "'.  First segment of end-to-end flow cannot refer to a flow sink.");
 					}
 				} else if (i == flow.getOwnedEndToEndFlowSegments().size() - 1) {
 					// last element of ETEF
 					if (((FlowSpecification) segment.getFlowElement()).getKind() == FlowKind.SOURCE) {
 						error(segment,
 								"Illegal reference to '" + segment.getContext().getName() + '.'
-										+ segment.getFlowElement().getName()
-										+ "'.  Last segment of end-to-end flow cannot refer to a flow source.");
+								+ segment.getFlowElement().getName()
+								+ "'.  Last segment of end-to-end flow cannot refer to a flow source.");
 					}
 				} else {
 					// an intermediate ETEF
@@ -2285,9 +2285,9 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 					if (noMatch) {
 						error(flow.getOwnedEndToEndFlowSegments().get(i),
 								"The source of connection '" + connection.getName()
-										+ "' does not match the preceding subcomponent or out flow spec feature '"
-										+ flow.getOwnedEndToEndFlowSegments().get(i - 1).getContext().getName() + '.'
-										+ outEnd.getFeature().getName() + '\'');
+								+ "' does not match the preceding subcomponent or out flow spec feature '"
+								+ flow.getOwnedEndToEndFlowSegments().get(i - 1).getContext().getName() + '.'
+								+ outEnd.getFeature().getName() + '\'');
 					}
 				} else if (i > 0
 						&& flow.getOwnedEndToEndFlowSegments().get(i - 1).getFlowElement() instanceof Subcomponent) {
@@ -2321,8 +2321,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 					if (noMatch) {
 						error(flow.getOwnedEndToEndFlowSegments().get(i),
 								"The source of connection '" + connection.getName()
-										+ "' does not match the preceding subcomponent or out flow spec feature '"
-										+ previousFlowSegment.getName() + '\'');
+								+ "' does not match the preceding subcomponent or out flow spec feature '"
+								+ previousFlowSegment.getName() + '\'');
 					}
 				}
 				if (didReverse) {
@@ -2362,9 +2362,9 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 						if (noMatch) {
 							error(flow.getOwnedEndToEndFlowSegments().get(i),
 									"The destination of connection '" + connection.getName()
-											+ "' does not match the succeeding subcomponent or in flow spec feature '"
-											+ flow.getOwnedEndToEndFlowSegments().get(i + 1).getContext().getName()
-											+ '.' + inEnd.getFeature().getName() + '\'');
+									+ "' does not match the succeeding subcomponent or in flow spec feature '"
+									+ flow.getOwnedEndToEndFlowSegments().get(i + 1).getContext().getName()
+									+ '.' + inEnd.getFeature().getName() + '\'');
 						}
 					} else if (felem instanceof Subcomponent) {
 						Subcomponent nextFlowSegment = (Subcomponent) felem;
@@ -2380,8 +2380,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 						if (noMatch) {
 							error(flow.getOwnedEndToEndFlowSegments().get(i),
 									"The destination of connection '" + connection.getName()
-											+ "' does not match the succeeding subcomponent or in flow spec feature '"
-											+ nextFlowSegment.getName() + '\'');
+									+ "' does not match the succeeding subcomponent or in flow spec feature '"
+									+ nextFlowSegment.getName() + '\'');
 						}
 					}
 				}
@@ -2421,7 +2421,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 								.get(referencedFlow.getOwnedEndToEndFlowSegments().size() - 1).getFlowElement();
 						if (referencedEndFlowSpec.getKind() == FlowKind.SINK) {
 							error(segment, "The last subcomponent flow of '" + referencedFlow.getName()
-									+ "' cannot be a flow sink.");
+							+ "' cannot be a flow sink.");
 						} else if (referencedEndFlowSpec.getKind() == FlowKind.PATH && flow
 								.getOwnedEndToEndFlowSegments().get(i + 1).getFlowElement() instanceof Connection) {
 							Connection nextConnection = (Connection) flow.getOwnedEndToEndFlowSegments().get(i + 1)
@@ -2430,8 +2430,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 									.getAllLastSource()) {
 								error(segment,
 										"The last subcomponent flow of '" + referencedFlow.getName()
-												+ "' does not name the same feature as the source of the succeeding connection '"
-												+ nextConnection.getName() + "'.");
+										+ "' does not name the same feature as the source of the succeeding connection '"
+										+ nextConnection.getName() + "'.");
 							}
 						}
 					}
@@ -2443,7 +2443,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 								.getOwnedEndToEndFlowSegments().get(0).getFlowElement();
 						if (referencedStartFlowSpec.getKind() == FlowKind.SOURCE) {
 							error(segment, "The first subcomponent flow of '" + referencedFlow.getName()
-									+ "' cannot be a flow source.");
+							+ "' cannot be a flow source.");
 						} else if (referencedStartFlowSpec.getKind() == FlowKind.PATH && flow
 								.getOwnedEndToEndFlowSegments().get(i - 1).getFlowElement() instanceof Connection) {
 							Connection previousConnection = (Connection) flow.getOwnedEndToEndFlowSegments().get(i - 1)
@@ -2452,8 +2452,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 									.getAllLastDestination()) {
 								error(segment,
 										"The first subcomponent flow of '" + referencedFlow.getName()
-												+ "' does not name the same feature as the destination of the preceding connection '"
-												+ previousConnection.getName() + "'.");
+										+ "' does not name the same feature as the destination of the preceding connection '"
+										+ previousConnection.getName() + "'.");
 							}
 						}
 					}
@@ -2563,7 +2563,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 					error(ne, ne.eClass().getName() + " identifier '" + ne.getName() + "' previously defined.");
 				} else if (ne instanceof FlowSpecification) {
 					error(ne, ne.eClass().getName() + " identifier '" + ne.getName()
-							+ "' previously defined. Maybe you forgot 'refined to'");
+					+ "' previously defined. Maybe you forgot 'refined to'");
 				} else {
 					Classifier classifier = ne.getContainingClassifier();
 					List<NamedElement> dupesInClassifier = findDupesInSameClassifier(classifier, ne);
@@ -2588,7 +2588,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 							|| ((duplicated instanceof AbstractFeature && ne instanceof Prototype)
 									|| (duplicated instanceof Prototype & ne instanceof AbstractFeature))) {
 						error(ne, duplicated.eClass().getName() + " identifier '" + ne.getName()
-								+ "' previously defined in " + duplicated.getContainingClassifier().getName());
+						+ "' previously defined in " + duplicated.getContainingClassifier().getName());
 					} else if (((ne instanceof Feature && ((Feature) ne).getRefined() != null)
 							&& (duplicated instanceof Feature && ((Feature) duplicated).getRefined() != null))
 							|| ((ne instanceof Prototype && ((Prototype) ne).getRefined() != null)
@@ -2851,32 +2851,28 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 	}
 
 	private EList<NamedElement> sortNamedElements(EList<NamedElement> list) {
-		Collections.sort(list, new Comparator<NamedElement>() {
-
-			@Override
-			public int compare(NamedElement a, NamedElement b) {
-				int aExtendCount = -1;
-				Classifier aExtended = a.getContainingClassifier();
-				while (null != aExtended) {
-					aExtendCount++;
-					if (aExtended instanceof ComponentImplementation && null == aExtended.getExtended()) {
-						aExtended = ((ComponentImplementation) aExtended).getType();
-					} else {
-						aExtended = aExtended.getExtended();
-					}
+		Collections.sort(list, (a, b) -> {
+			int aExtendCount = -1;
+			Classifier aExtended = a.getContainingClassifier();
+			while (null != aExtended) {
+				aExtendCount++;
+				if (aExtended instanceof ComponentImplementation && null == aExtended.getExtended()) {
+					aExtended = ((ComponentImplementation) aExtended).getType();
+				} else {
+					aExtended = aExtended.getExtended();
 				}
-				int bExtendCount = -1;
-				Classifier bExtended = b.getContainingClassifier();
-				while (null != bExtended) {
-					bExtendCount++;
-					if (bExtended instanceof ComponentImplementation && null == bExtended.getExtended()) {
-						bExtended = ((ComponentImplementation) bExtended).getType();
-					} else {
-						bExtended = bExtended.getExtended();
-					}
-				}
-				return aExtendCount - bExtendCount;
 			}
+			int bExtendCount = -1;
+			Classifier bExtended = b.getContainingClassifier();
+			while (null != bExtended) {
+				bExtendCount++;
+				if (bExtended instanceof ComponentImplementation && null == bExtended.getExtended()) {
+					bExtended = ((ComponentImplementation) bExtended).getType();
+				} else {
+					bExtended = bExtended.getExtended();
+				}
+			}
+			return aExtendCount - bExtendCount;
 		});
 		return list;
 	}
@@ -2919,7 +2915,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 						|| ((duplicated instanceof AbstractFeature && ne instanceof Prototype)
 								|| (duplicated instanceof Prototype & ne instanceof AbstractFeature))) {
 					error(ne, duplicated.eClass().getName() + " identifier '" + ne.getName()
-							+ "' previously defined in " + duplicated.getContainingClassifier().getName());
+					+ "' previously defined in " + duplicated.getContainingClassifier().getName());
 				} else if (((ne instanceof Feature && ((Feature) ne).getRefined() != null)
 						&& (duplicated instanceof Feature && ((Feature) duplicated).getRefined() != null))
 						|| ((ne instanceof Prototype && ((Prototype) ne).getRefined() != null)
@@ -2965,7 +2961,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 		if (componentImplementation.getOwner() instanceof PublicPackageSection
 				&& ((AadlPackage) componentImplementation.getElementRoot()).getPrivateSection() != null
 				&& ((AadlPackage) componentImplementation.getElementRoot()).getPrivateSection()
-						.findNamedElement(componentImplementation.getName()) instanceof ComponentImplementation) {
+				.findNamedElement(componentImplementation.getName()) instanceof ComponentImplementation) {
 			for (EObject child : componentImplementation.getOwnedElements()) {
 				if (child instanceof ClassifierFeature && !(child instanceof ModeFeature)) {
 					error("When a component implementation is declared in both the public section and the private"
@@ -3099,7 +3095,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 		ComponentType type = realization.getImplemented();
 		if (Aadl2Util.isNull(type)) {
 			return; // unresolved type. has been reported already as such. no
-					// need to check category
+			// need to check category
 		}
 		ComponentImplementation implementation = (ComponentImplementation) realization.getSpecific();
 		if (!type.getCategory().equals(implementation.getCategory())) {
@@ -3324,8 +3320,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 			if (!acceptableSubcomponentCategories.contains(subcomponentCategory)) {
 				error(componentImplementation.getOwnedExtension(),
 						"A " + implementationCategory.getName()
-								+ " implementation cannot extend an abstract implementation that contains a "
-								+ subcomponentCategory.getName() + " subcomponent.");
+						+ " implementation cannot extend an abstract implementation that contains a "
+						+ subcomponentCategory.getName() + " subcomponent.");
 			}
 		}
 	}
@@ -3451,10 +3447,10 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 		if (refinedSubcomponent.getClassifier() instanceof AbstractType) {
 			abstractType = (AbstractType) refinedSubcomponent.getClassifier();
 		} else if (refinedSubcomponent.getClassifier() instanceof AbstractImplementation &&
-		// This second part of this if expression will not be false for
-		// semantically correct models.
+				// This second part of this if expression will not be false for
+				// semantically correct models.
 				((AbstractImplementation) refinedSubcomponent.getClassifier()).getOwnedRealization()
-						.getImplemented() instanceof AbstractType) {
+				.getImplemented() instanceof AbstractType) {
 			abstractType = ((AbstractImplementation) refinedSubcomponent.getClassifier()).getType();
 		} else {
 			abstractType = null;
@@ -3547,13 +3543,13 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 							: getComponentPrototypeCategory((ComponentPrototype) st))) {
 				ComponentCategory componentCategory = st instanceof ComponentClassifier
 						? ((ComponentClassifier) st).getCategory()
-						: getComponentPrototypeCategory((ComponentPrototype) st);
-				String changeFrom = actual.getCategory().getName();
-				String changeTo = componentCategory.getName();
-				String offset = "" + findKeywordOffset(actual, changeFrom);
+								: getComponentPrototypeCategory((ComponentPrototype) st);
+						String changeFrom = actual.getCategory().getName();
+						String changeTo = componentCategory.getName();
+						String offset = "" + findKeywordOffset(actual, changeFrom);
 
-				error("The category of the referenced classifier is not compatible the category specified in the prototype binding.",
-						actual, null, GENERIC_TEXT_REPLACEMENT, changeFrom, changeTo, offset);
+						error("The category of the referenced classifier is not compatible the category specified in the prototype binding.",
+								actual, null, GENERIC_TEXT_REPLACEMENT, changeFrom, changeTo, offset);
 			}
 		}
 	}
@@ -3790,7 +3786,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 		}
 		for (ComponentImplementation parentImplementation = dataImplementation
 				.getExtended(); parentImplementation instanceof AbstractImplementation; parentImplementation = parentImplementation
-						.getExtended()) {
+				.getExtended()) {
 			if (!parentImplementation.getOwnedFlowImplementations().isEmpty()) {
 				parentHasFlowImpl = true;
 			}
@@ -3995,7 +3991,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 		}
 		for (ComponentImplementation parentImplementation = threadGroupImplementation
 				.getExtended(); parentImplementation instanceof AbstractImplementation; parentImplementation = parentImplementation
-						.getExtended()) {
+				.getExtended()) {
 			if (!((AbstractImplementation) parentImplementation).getOwnedSubprogramCallSequences().isEmpty()) {
 				parentHasCallSequence = true;
 			}
@@ -4020,7 +4016,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 		}
 		for (ComponentImplementation parentImplementation = processorImplementation
 				.getExtended(); parentImplementation instanceof AbstractImplementation; parentImplementation = parentImplementation
-						.getExtended()) {
+				.getExtended()) {
 			if (!((AbstractImplementation) parentImplementation).getOwnedSubprogramCallSequences().isEmpty()) {
 				parentHasCallSequence = true;
 			}
@@ -4045,7 +4041,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 		}
 		for (ComponentImplementation parentImplementation = virtualProcessorImplementation
 				.getExtended(); parentImplementation instanceof AbstractImplementation; parentImplementation = parentImplementation
-						.getExtended()) {
+				.getExtended()) {
 			if (!((AbstractImplementation) parentImplementation).getOwnedSubprogramCallSequences().isEmpty()) {
 				parentHasCallSequence = true;
 			}
@@ -4100,7 +4096,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 		}
 		for (ComponentImplementation parentImplementation = memoryImplementation
 				.getExtended(); parentImplementation instanceof AbstractImplementation; parentImplementation = parentImplementation
-						.getExtended()) {
+				.getExtended()) {
 			if (!parentImplementation.getOwnedFlowImplementations().isEmpty()) {
 				parentHasFlowImpl = true;
 			}
@@ -4169,7 +4165,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 		}
 		for (ComponentImplementation parentImplementation = busImplementation
 				.getExtended(); parentImplementation instanceof AbstractImplementation; parentImplementation = parentImplementation
-						.getExtended()) {
+				.getExtended()) {
 			if (!parentImplementation.getOwnedConnections().isEmpty()) {
 				parentHasConnections = true;
 			}
@@ -4245,7 +4241,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 		}
 		for (ComponentImplementation parentImplementation = virtualBusImplementation
 				.getExtended(); parentImplementation instanceof AbstractImplementation; parentImplementation = parentImplementation
-						.getExtended()) {
+				.getExtended()) {
 			if (!parentImplementation.getOwnedConnections().isEmpty()) {
 				parentHasConnections = true;
 			}
@@ -4290,7 +4286,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 		}
 		for (ComponentImplementation parentImplementation = deviceImplementation
 				.getExtended(); parentImplementation instanceof AbstractImplementation; parentImplementation = parentImplementation
-						.getExtended()) {
+				.getExtended()) {
 			if (!((AbstractImplementation) parentImplementation).getOwnedSubprogramCallSequences().isEmpty()) {
 				parentHasCallSequence = true;
 			}
@@ -5076,7 +5072,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 					if (!testClassifierMatchRule(connection, source, sourceClassifier, destination,
 							destinationClassifier)) {
 						error(connection, '\'' + source.getName() + "' and '" + destination.getName()
-								+ "' have incompatible classifiers.");
+						+ "' have incompatible classifiers.");
 					}
 				} else if (ModelingProperties.EQUIVALENCE.equalsIgnoreCase(classifierMatchingRuleValue)) {
 					if (!testClassifierMatchRule(connection, source, sourceClassifier, destination,
@@ -5095,10 +5091,10 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 							destinationClassifier) && !isDataSubset(sourceClassifier, destinationClassifier)) {
 						error(connection,
 								"The data type of '" + source.getName() + "' ('" + sourceClassifier.getQualifiedName()
-										+ "') is not a subset of the data type of '" + destination.getName() + "' ('"
-										+ destinationClassifier.getQualifiedName()
-										+ "') based on name matching or the property constant '"
-										+ AadlProject.SUPPORTED_CLASSIFIER_SUBSET_MATCHES + "'.");
+								+ "') is not a subset of the data type of '" + destination.getName() + "' ('"
+								+ destinationClassifier.getQualifiedName()
+								+ "') based on name matching or the property constant '"
+								+ AadlProject.SUPPORTED_CLASSIFIER_SUBSET_MATCHES + "'.");
 					}
 				} else if (ModelingProperties.CONVERSION.equalsIgnoreCase(classifierMatchingRuleValue)) {
 					if (!testClassifierMatchRule(connection, source, sourceClassifier, destination,
@@ -5124,13 +5120,13 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 			if (sourceClassifier instanceof ComponentType && destinationClassifier instanceof ComponentImplementation) {
 				if (!sourceClassifier.equals(((ComponentImplementation) destinationClassifier).getType())) {
 					warning(connection, "The types of '" + source.getName() + "' and '" + destination.getName()
-							+ "' do not match.");
+					+ "' do not match.");
 				}
 			} else if (sourceClassifier instanceof ComponentImplementation
 					&& destinationClassifier instanceof ComponentType) {
 				if (!destinationClassifier.equals(((ComponentImplementation) sourceClassifier).getType())) {
 					warning(connection, "The types of '" + source.getName() + "' and '" + destination.getName()
-							+ "' do not match.");
+					+ "' do not match.");
 				}
 			} else {
 				return false;
@@ -5352,8 +5348,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 				|| (srcContext == null && source instanceof DataSubcomponent && dstContext instanceof Subcomponent)
 				// from a data subcomponent to a port
 				|| (dstContext == null && destination instanceof DataSubcomponent && srcContext instanceof Subcomponent)
-		// from a data subcomponent to a port
-		) {
+				// from a data subcomponent to a port
+				) {
 			if (!(srcDirection.outgoing() && dstDirection.incoming())) {
 				error(connection, "Source must be outgoing and destination incoming.");
 			}
@@ -5542,44 +5538,44 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 			if (source instanceof EventPort
 					&& !(destination instanceof EventPort || destination instanceof EventSource)) {
 				error(connection, "Source event port '" + source.getName()
-						+ "' must be connected to an (internal) event port destination.");
+				+ "' must be connected to an (internal) event port destination.");
 				return;
 			}
 			if (source instanceof EventSource && !(destination instanceof EventPort)) {
 				error(connection, "Source internal event port '" + source.getName()
-						+ "' must be connected to an event port destination.");
+				+ "' must be connected to an event port destination.");
 				return;
 			}
 			if (source instanceof DataPort && !(destination instanceof EventPort || destination instanceof DataPort
 					|| destination instanceof EventDataPort || destination instanceof DataSubcomponent
 					|| destination instanceof DataAccess)) {
 				error(connection, "Source data port '" + source.getName()
-						+ "' must be connected to an event, data, or event data port, data subcomponent or data access destination.");
+				+ "' must be connected to an event, data, or event data port, data subcomponent or data access destination.");
 				return;
 			}
 			if (source instanceof EventDataPort && !(destination instanceof EventPort || destination instanceof DataPort
 					|| destination instanceof EventDataPort || destination instanceof DataSubcomponent
 					|| destination instanceof DataAccess || destination instanceof EventDataSource)) {
 				error(connection, "Source event data port '" + source.getName()
-						+ "' must be connected to an event, data, or event data port, internal event data port, data subcomponent or data access destination.");
+				+ "' must be connected to an event, data, or event data port, internal event data port, data subcomponent or data access destination.");
 				return;
 			}
 			if (source instanceof DataSubcomponent && !(destination instanceof EventPort
 					|| destination instanceof DataPort || destination instanceof EventDataPort)) {
 				error(connection, "Source data subcomponent '" + source.getName()
-						+ "' must be connected to an event, data, or event data port destination.");
+				+ "' must be connected to an event, data, or event data port destination.");
 				return;
 			}
 			if (source instanceof DataAccess && !(destination instanceof EventPort || destination instanceof DataPort
 					|| destination instanceof EventDataPort)) {
 				error(connection, "Source data access feature '" + source.getName()
-						+ "' must be connected to an event, data, or event data port destination.");
+				+ "' must be connected to an event, data, or event data port destination.");
 				return;
 			}
 			if (source instanceof EventDataSource
 					&& !(destination instanceof EventDataPort || destination instanceof DataPort)) {
 				error(connection, "Source internal event data port '" + source.getName()
-						+ "' must be connected to an event data port destination.");
+				+ "' must be connected to an event data port destination.");
 				return;
 			}
 		}
@@ -5588,9 +5584,9 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 	private void checkAggregateDataPort(PortConnection connection) {
 		if (connection.getRefined() == null) {
 			Arrays.asList(connection.getSource(), connection.getDestination()).stream()
-					.filter(ce -> ce.getContext() instanceof Feature
-							&& ce.getConnectionEnd() instanceof DataSubcomponent)
-					.forEach(ce -> warning(ce, "Aggregate data ports not supported by instantiator."));
+			.filter(ce -> ce.getContext() instanceof Feature
+					&& ce.getConnectionEnd() instanceof DataSubcomponent)
+			.forEach(ce -> warning(ce, "Aggregate data ports not supported by instantiator."));
 		}
 	}
 
@@ -5628,7 +5624,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 					if (!testClassifierMatchRule(connection, source, sourceClassifier, destination,
 							destinationClassifier)) {
 						error(connection, '\'' + source.getName() + "' and '" + destination.getName()
-								+ "' have incompatible classifiers.");
+						+ "' have incompatible classifiers.");
 					}
 				} else if (classifierMatchingRuleValue.equalsIgnoreCase(ModelingProperties.EQUIVALENCE)) {
 					if (!testClassifierMatchRule(connection, source, sourceClassifier, destination,
@@ -5698,8 +5694,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 			}
 		} else {
 			error("Anything in " + getEClassDisplayNameWithIndefiniteArticle(connectionContext.eClass())
-					+ " is not a valid access connection end.", connectedElement,
-					Aadl2Package.eINSTANCE.getConnectedElement_Context());
+			+ " is not a valid access connection end.", connectedElement,
+			Aadl2Package.eINSTANCE.getConnectedElement_Context());
 		}
 	}
 
@@ -5728,8 +5724,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 			}
 		} else {
 			error("Anything in " + getEClassDisplayNameWithIndefiniteArticle(connectionContext.eClass())
-					+ " is not a valid feature connection end.", connectedElement,
-					Aadl2Package.eINSTANCE.getConnectedElement_Context());
+			+ " is not a valid feature connection end.", connectedElement,
+			Aadl2Package.eINSTANCE.getConnectedElement_Context());
 		}
 	}
 
@@ -5757,8 +5753,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 			}
 		} else {
 			error("Anything in " + getEClassDisplayNameWithIndefiniteArticle(connectionContext.eClass())
-					+ " is not a valid feature group connection end.", connectedElement,
-					Aadl2Package.eINSTANCE.getConnectedElement_Context());
+			+ " is not a valid feature group connection end.", connectedElement,
+			Aadl2Package.eINSTANCE.getConnectedElement_Context());
 		}
 	}
 
@@ -5801,8 +5797,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 			}
 		} else {
 			error("Anything in " + getEClassDisplayNameWithIndefiniteArticle(connectionContext.eClass())
-					+ " is not a valid parameter connection end.", connectedElement,
-					Aadl2Package.eINSTANCE.getConnectedElement_Context());
+			+ " is not a valid parameter connection end.", connectedElement,
+			Aadl2Package.eINSTANCE.getConnectedElement_Context());
 		}
 	}
 
@@ -5846,8 +5842,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 			}
 		} else {
 			error("Anything in " + getEClassDisplayNameWithIndefiniteArticle(connectionContext.eClass())
-					+ " is not a valid port connection end.", connectedElement,
-					Aadl2Package.eINSTANCE.getConnectedElement_Context());
+			+ " is not a valid port connection end.", connectedElement,
+			Aadl2Package.eINSTANCE.getConnectedElement_Context());
 		}
 	}
 
@@ -5869,8 +5865,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 			}
 		} else if (triggerContext != null) {
 			error("Anything in " + getEClassDisplayNameWithIndefiniteArticle(triggerContext.eClass())
-					+ " is not a valid mode transition trigger.", trigger,
-					Aadl2Package.eINSTANCE.getModeTransitionTrigger_Context());
+			+ " is not a valid mode transition trigger.", trigger,
+			Aadl2Package.eINSTANCE.getModeTransitionTrigger_Context());
 		}
 	}
 
@@ -6012,8 +6008,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 				&& (dstContext == null || dstContext instanceof FeatureGroup)) {
 			if (!destinationType.equals(AccessType.PROVIDES)) {
 				error('\'' + destination.getName()
-						+ "' must be a provides access feature for a connection from an accessed subcomponent.",
-						connection, Aadl2Package.eINSTANCE.getConnection_Destination());
+				+ "' must be a provides access feature for a connection from an accessed subcomponent.",
+				connection, Aadl2Package.eINSTANCE.getConnection_Destination());
 			}
 		}
 		// Test for L6: connection between access feature and subcomponent
@@ -6021,8 +6017,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 				&& (srcContext == null || srcContext instanceof FeatureGroup)) {
 			if (!sourceType.equals(AccessType.PROVIDES)) {
 				error('\'' + source.getName()
-						+ "' must be a provides access feature for a connection to a accessed subcomponent.",
-						connection, Aadl2Package.eINSTANCE.getConnection_Source());
+				+ "' must be a provides access feature for a connection to a accessed subcomponent.",
+				connection, Aadl2Package.eINSTANCE.getConnection_Source());
 			}
 		}
 		// Test for L7: connection between subcomponent and access feature of
@@ -6031,8 +6027,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 				&& dstContext instanceof Subcomponent) {
 			if (!destinationType.equals(AccessType.REQUIRES)) {
 				error('\'' + destination.getName()
-						+ "' must be a requires access feature for a connection from an accessed subcomponent.",
-						connection, Aadl2Package.eINSTANCE.getConnection_Destination());
+				+ "' must be a requires access feature for a connection from an accessed subcomponent.",
+				connection, Aadl2Package.eINSTANCE.getConnection_Destination());
 			}
 		}
 		// Test for L7: connection between access feature of subcomponent and
@@ -6041,8 +6037,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 				&& srcContext instanceof Subcomponent) {
 			if (!sourceType.equals(AccessType.REQUIRES)) {
 				error('\'' + source.getName()
-						+ "' must be a requires access feature for a connection to an accessed subcomponent.",
-						connection, Aadl2Package.eINSTANCE.getConnection_Source());
+				+ "' must be a requires access feature for a connection to an accessed subcomponent.",
+				connection, Aadl2Package.eINSTANCE.getConnection_Source());
 			}
 		}
 	}
@@ -6099,7 +6095,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 					if (!testClassifierMatchRule(connection, source, sourceClassifier, destination,
 							destinationClassifier)) {
 						error(connection, '\'' + source.getName() + "' and '" + destination.getName()
-								+ "' have incompatible classifiers.");
+						+ "' have incompatible classifiers.");
 					}
 				} else if (classifierMatchingRuleValue.equalsIgnoreCase(ModelingProperties.EQUIVALENCE)) {
 					if (!testClassifierMatchRule(connection, source, sourceClassifier, destination,
@@ -6155,14 +6151,14 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 		}
 		if (flowEndContext != null && !(flowEndContext instanceof FeatureGroup)) {
 			error("Anything in " + getEClassDisplayNameWithIndefiniteArticle(flowEndContext.eClass())
-					+ " is not a valid flow specification feature.", flowEnd,
-					Aadl2Package.eINSTANCE.getFlowEnd_Context());
+			+ " is not a valid flow specification feature.", flowEnd,
+			Aadl2Package.eINSTANCE.getFlowEnd_Context());
 		} else if (!(flowFeature instanceof DataAccess) && !(flowFeature instanceof AbstractFeature)
 				&& !(flowFeature instanceof FeatureGroup) && !(flowFeature instanceof Parameter)
 				&& !(flowFeature instanceof Port)) {
 			error('\'' + (flowEndContext != null ? flowEndContext.getName() + '.' : "") + flowFeature.getName()
-					+ "' must be a port, parameter, data access, feature group, or abstract feature.", flowEnd,
-					Aadl2Package.eINSTANCE.getFlowEnd_Feature());
+			+ "' must be a port, parameter, data access, feature group, or abstract feature.", flowEnd,
+			Aadl2Package.eINSTANCE.getFlowEnd_Feature());
 		}
 	}
 
@@ -6318,8 +6314,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 				if (report) {
 					error(flow.getOutEnd(),
 							'\'' + (flow.getOutEnd().getContext() != null
-									? flow.getOutEnd().getContext().getName() + '.' : "") + outFeature.getName()
-									+ "' must be an out or in out feature.");
+							? flow.getOutEnd().getContext().getName() + '.' : "") + outFeature.getName()
+							+ "' must be an out or in out feature.");
 				}
 				return false;
 			} else {
@@ -6338,8 +6334,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 				if (report) {
 					error(flow.getOutEnd(),
 							'\'' + (flow.getOutEnd().getContext() != null
-									? flow.getOutEnd().getContext().getName() + '.' : "") + outFeature.getName()
-									+ "' must have an access right of Write_Only or Read_Write.");
+							? flow.getOutEnd().getContext().getName() + '.' : "") + outFeature.getName()
+							+ "' must have an access right of Write_Only or Read_Write.");
 				}
 				return false;
 			} else {
@@ -7435,16 +7431,16 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 				// sibling to sibling
 				if (sourceDirection.equals(DirectionType.IN)) {
 					error("The direction of the source " + source.getName()
-							+ " of a directional feature group connection must not be in", connection,
-							Aadl2Package.eINSTANCE.getConnection_Source(), MAKE_CONNECTION_BIDIRECTIONAL);
+					+ " of a directional feature group connection must not be in", connection,
+					Aadl2Package.eINSTANCE.getConnection_Source(), MAKE_CONNECTION_BIDIRECTIONAL);
 				} else if (sourceDirection.equals(DirectionType.IN_OUT)) {
 					checkDirectionOfFeatureGroupMembers(sourceChain, DirectionType.IN, connection,
 							Aadl2Package.eINSTANCE.getConnection_Source());
 				}
 				if (destinationDirection.equals(DirectionType.OUT)) {
 					error("The direction of the destination " + destination.getName()
-							+ " of a directional feature group connection must not be out", connection,
-							Aadl2Package.eINSTANCE.getConnection_Destination(), MAKE_CONNECTION_BIDIRECTIONAL);
+					+ " of a directional feature group connection must not be out", connection,
+					Aadl2Package.eINSTANCE.getConnection_Destination(), MAKE_CONNECTION_BIDIRECTIONAL);
 				} else if (destinationDirection.equals(DirectionType.IN_OUT)) {
 					checkDirectionOfFeatureGroupMembers(destinationChain, DirectionType.OUT, connection,
 							Aadl2Package.eINSTANCE.getConnection_Destination());
@@ -7453,8 +7449,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 				// going down
 				if (sourceDirection.equals(DirectionType.OUT)) {
 					error("The direction of the source " + source.getName()
-							+ " of this incoming directional feature group connection must not be out", connection,
-							Aadl2Package.eINSTANCE.getConnection_Source(), MAKE_CONNECTION_BIDIRECTIONAL);
+					+ " of this incoming directional feature group connection must not be out", connection,
+					Aadl2Package.eINSTANCE.getConnection_Source(), MAKE_CONNECTION_BIDIRECTIONAL);
 				} else if (sourceDirection.equals(DirectionType.IN_OUT)) {
 					checkDirectionOfFeatureGroupMembers(sourceChain, DirectionType.OUT, connection,
 							Aadl2Package.eINSTANCE.getConnection_Source());
@@ -7462,8 +7458,8 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 
 				if (destinationDirection.equals(DirectionType.OUT)) {
 					error("The direction of the destination " + destination.getName()
-							+ " of this incoming directional feature group connection must not be out", connection,
-							Aadl2Package.eINSTANCE.getConnection_Destination(), MAKE_CONNECTION_BIDIRECTIONAL);
+					+ " of this incoming directional feature group connection must not be out", connection,
+					Aadl2Package.eINSTANCE.getConnection_Destination(), MAKE_CONNECTION_BIDIRECTIONAL);
 				} else if (destinationDirection.equals(DirectionType.IN_OUT)) {
 					checkDirectionOfFeatureGroupMembers(destinationChain, DirectionType.OUT, connection,
 							Aadl2Package.eINSTANCE.getConnection_Destination());
@@ -7472,16 +7468,16 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 				// going up
 				if (sourceDirection.equals(DirectionType.IN)) {
 					error("The direction of the source " + source.getName()
-							+ " of this outgoing directional feature group connection must not be in", connection,
-							Aadl2Package.eINSTANCE.getConnection_Destination(), MAKE_CONNECTION_BIDIRECTIONAL);
+					+ " of this outgoing directional feature group connection must not be in", connection,
+					Aadl2Package.eINSTANCE.getConnection_Destination(), MAKE_CONNECTION_BIDIRECTIONAL);
 				} else if (sourceDirection.equals(DirectionType.IN_OUT)) {
 					checkDirectionOfFeatureGroupMembers(sourceChain, DirectionType.IN, connection,
 							Aadl2Package.eINSTANCE.getConnection_Source());
 				}
 				if (destinationDirection.equals(DirectionType.IN)) {
 					error("The direction of the destination " + destination.getName()
-							+ " of this outgoing directional feature group connection must not be in", connection,
-							Aadl2Package.eINSTANCE.getConnection_Destination(), MAKE_CONNECTION_BIDIRECTIONAL);
+					+ " of this outgoing directional feature group connection must not be in", connection,
+					Aadl2Package.eINSTANCE.getConnection_Destination(), MAKE_CONNECTION_BIDIRECTIONAL);
 				} else if (destinationDirection.equals(DirectionType.IN_OUT)) {
 					checkDirectionOfFeatureGroupMembers(destinationChain, DirectionType.IN, connection,
 							Aadl2Package.eINSTANCE.getConnection_Destination());
@@ -7520,27 +7516,27 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 			return;
 		}
 		fgt.getAllFeatures().stream()
-				.filter(feature -> feature instanceof DirectedFeature)
-				.map(feature -> (DirectedFeature) feature)
-				.filter(feature -> feature.getDirection() != DirectionType.IN_OUT)
-				.forEach(feature -> {
-					DirectionType featureDirection = feature.getDirection();
-					List<NamedElement> chainWithFeature = new ArrayList<>(chain);
-					chainWithFeature.add(feature);
-					if (isInvertNeeded(chainWithFeature)) {
-						featureDirection = featureDirection.getInverseDirection();
-					}
-					if (featureDirection == notDir) {
-						String chainName = chainWithFeature.stream()
-								.map(chainElement -> chainElement.getName())
-								.collect(Collectors.joining("."));
-						error("Feature " + chainName + " must not be " + notDir.getName()
-								+ " due to the direction of the connection", conn, structuralFeature,
-								MAKE_CONNECTION_BIDIRECTIONAL);
-					}
-				});
+		.filter(feature -> feature instanceof DirectedFeature)
+		.map(feature -> (DirectedFeature) feature)
+		.filter(feature -> feature.getDirection() != DirectionType.IN_OUT)
+		.forEach(feature -> {
+			DirectionType featureDirection = feature.getDirection();
+			List<NamedElement> chainWithFeature = new ArrayList<>(chain);
+			chainWithFeature.add(feature);
+			if (isInvertNeeded(chainWithFeature)) {
+				featureDirection = featureDirection.getInverseDirection();
+			}
+			if (featureDirection == notDir) {
+				String chainName = chainWithFeature.stream()
+						.map(chainElement -> chainElement.getName())
+						.collect(Collectors.joining("."));
+				error("Feature " + chainName + " must not be " + notDir.getName()
+				+ " due to the direction of the connection", conn, structuralFeature,
+				MAKE_CONNECTION_BIDIRECTIONAL);
+			}
+		});
 	}
-	
+
 	private List<NamedElement> getConnectionChain(ConnectedElement connectedElement) {
 		List<NamedElement> chain = new ArrayList<>();
 		ConnectedElement current = connectedElement;
@@ -7559,14 +7555,14 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 	 */
 	private boolean isInvertNeeded(List<NamedElement> chain) {
 		boolean chainInverts = false;
-		
+
 		//Check 'inverse of' in the feature group.
 		for (NamedElement chainElement : chain) {
 			if (chainElement instanceof FeatureGroup) {
 				chainInverts ^= ((FeatureGroup) chainElement).isInverse();
 			}
 		}
-		
+
 		//Check 'inverse of' in the feature group type.
 		for (int i = 0; i < chain.size() - 1; i++) {
 			NamedElement context = chain.get(i);
@@ -7589,10 +7585,10 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 				}
 			}
 		}
-		
+
 		return chainInverts;
 	}
-	
+
 	/**
 	 * Checks that direction of matching features in feature group are opposite or the same.
 	 * This method is useful when the feature group types of the source and destination are independently specified
@@ -7659,10 +7655,10 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 									if (sourceDirection != destinationDirection) {
 										error(connection,
 												"The direction of the source feature group feature '" + source.getName()
-														+ "." + sourceFeature.getName()
-														+ "' and destination feature group feature '"
-														+ destination.getName() + "." + destinationFeature.getName()
-														+ "' of connection " + connection.getName() + " must be same.");
+												+ "." + sourceFeature.getName()
+												+ "' and destination feature group feature '"
+												+ destination.getName() + "." + destinationFeature.getName()
+												+ "' of connection " + connection.getName() + " must be same.");
 									}
 								}
 							} else {
@@ -7807,7 +7803,7 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 				if (!testIfFeatureGroupsAreInverses(connection.getRootConnection().getSource(),
 						connection.getRootConnection().getDestination())) {
 					error(connection, "The feature groups '" + source.getName() + "' and '" + destination.getName()
-							+ "' are not inverses of each other.");
+					+ "' are not inverses of each other.");
 				}
 			} else if (ModelingProperties.EQUIVALENCE.equalsIgnoreCase(classifierMatchingRuleValue)) {
 				warning(connection, "The classifier matching rule '" + ModelingProperties.EQUIVALENCE
@@ -7832,14 +7828,14 @@ public class Aadl2JavaValidator extends AbstractAadl2JavaValidator {
 		} else { // up or down hierarchy
 			if (ModelingProperties.CLASSIFIER_MATCH.equalsIgnoreCase(classifierMatchingRuleValue)
 					|| ModelingProperties.CONVERSION.equalsIgnoreCase(classifierMatchingRuleValue)
-			// ||
-			// ModelingProperties.COMPLEMENT.equalsIgnoreCase(classifierMatchingRuleValue.getName())
-			) {
+					// ||
+					// ModelingProperties.COMPLEMENT.equalsIgnoreCase(classifierMatchingRuleValue.getName())
+					) {
 				if (ModelingProperties.CONVERSION.equalsIgnoreCase(classifierMatchingRuleValue)) {
 					warning(connection,
 							"The classifier matching rule '" + ModelingProperties.CONVERSION
-									+ "' is not supported for feature group connections. Using rule '"
-									+ ModelingProperties.CLASSIFIER_MATCH + "' instead.");
+							+ "' is not supported for feature group connections. Using rule '"
+							+ ModelingProperties.CLASSIFIER_MATCH + "' instead.");
 				}
 				// if (classifierMatchingRuleValue != null &&
 				// ModelingProperties.COMPLEMENT.equalsIgnoreCase(classifierMatchingRuleValue.getName()))


### PR DESCRIPTION
Fixes osate/osate2-core#931
It now does comparison of feature names rather than feature objects. The issue was that we had inherited and refined features that the flow was pointing to.
The same test was in place a few lines earlier.