### PR TITLE
Fixes #961: Fixed instantiateSubcomponent()

### DIFF
--- a/org.osate.core.tests/models/issue961/.gitignore
+++ b/org.osate.core.tests/models/issue961/.gitignore
@@ -1,0 +1,1 @@
+/.aadlbin-gen/

--- a/org.osate.core.tests/models/issue961/.project
+++ b/org.osate.core.tests/models/issue961/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Issue961</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/org.osate.core.tests/models/issue961/abstractprocess.aadl
+++ b/org.osate.core.tests/models/issue961/abstractprocess.aadl
@@ -1,0 +1,24 @@
+package abstractprocess
+public
+	system s
+	end s;
+	
+	system implementation s.i
+	subcomponents
+		p: process a; -- subcomponent is a process
+		b: bus a; -- subcomponent is a bus
+	end s.i;
+	
+	system implementation s.j
+		subcomponents
+			x: abstract a; -- subcomponent is still abstract
+	end s.j;
+	
+	system implementation s.k extends s.j
+		subcomponents
+			x: refined to process a; -- subcomponent is now a process
+	end s.k;
+	
+	abstract a
+	end a;
+end abstractprocess;

--- a/org.osate.core.tests/models/issue961/abstractprocess.aadl
+++ b/org.osate.core.tests/models/issue961/abstractprocess.aadl
@@ -5,8 +5,8 @@ public
 	
 	system implementation s.i
 	subcomponents
-		p: process a; -- subcomponent is a process
-		b: bus a; -- subcomponent is a bus
+		p: process a; -- subcomponent is a process; error was that this showed up as abstract
+		b: bus a; -- subcomponent is a bus; error was that this showed up as abstract
 	end s.i;
 	
 	system implementation s.j

--- a/org.osate.core.tests/models/issue961/abstractprocess.aadl
+++ b/org.osate.core.tests/models/issue961/abstractprocess.aadl
@@ -10,13 +10,13 @@ public
 	end s.i;
 	
 	system implementation s.j
-		subcomponents
-			x: abstract a; -- subcomponent is still abstract
+	subcomponents
+		x: abstract a; -- subcomponent is still abstract
 	end s.j;
 	
 	system implementation s.k extends s.j
-		subcomponents
-			x: refined to process a; -- subcomponent is now a process
+	subcomponents
+		x: refined to process a; -- subcomponent is now a process
 	end s.k;
 	
 	abstract a

--- a/org.osate.core.tests/models/issue961/package2.aadl
+++ b/org.osate.core.tests/models/issue961/package2.aadl
@@ -1,0 +1,33 @@
+package package2
+public
+	system SS
+		prototypes
+			X: abstract;
+	end SS;
+
+	system implementation SS.i
+		subcomponents
+			s1: abstract X;
+	end SS.i;
+	
+	bus B1
+	end B1;
+	
+	bus implementation B1.i
+	end B1.i;
+	
+	process P1
+	end P1;
+	
+	process implementation P1.i
+	end P1.i;
+	
+	system SSS
+	end SSS;
+	
+	system implementation SSS.i
+		subcomponents
+			sub1: system SS.i (X => bus B1.i); -- subcomponent sub1.s1 is a bus
+			sub2: system SS.i (X => process P1.i); -- subcomponent sub2.s1 is a process
+	end SSS.i;
+end package2;

--- a/org.osate.core.tests/models/issue961/package2.aadl
+++ b/org.osate.core.tests/models/issue961/package2.aadl
@@ -1,5 +1,15 @@
 package package2
 public
+	system SS
+		prototypes
+			X: abstract;
+	end SS;
+
+	system implementation SS.i
+		subcomponents
+			s1: abstract X;
+	end SS.i;
+	
 	bus B1
 	end B1;
 	

--- a/org.osate.core.tests/models/issue961/package2.aadl
+++ b/org.osate.core.tests/models/issue961/package2.aadl
@@ -1,15 +1,5 @@
 package package2
 public
-	system SS
-		prototypes
-			X: abstract;
-	end SS;
-
-	system implementation SS.i
-		subcomponents
-			s1: abstract X;
-	end SS.i;
-	
 	bus B1
 	end B1;
 	

--- a/org.osate.core.tests/src/org/osate/core/tests/issues/Issue961Test.xtend
+++ b/org.osate.core.tests/src/org/osate/core/tests/issues/Issue961Test.xtend
@@ -1,0 +1,84 @@
+package org.osate.core.tests.issues
+
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.osate.aadl2.AadlPackage
+import org.osate.core.test.Aadl2UiInjectorProvider
+import org.osate.core.test.OsateTest
+
+import static org.junit.Assert.*
+import org.osate.aadl2.SystemImplementation
+import org.osate.aadl2.instantiation.InstantiateModel
+import org.osate.aadl2.ComponentCategory
+import org.osate.aadl2.instance.SystemInstance
+
+@RunWith(XtextRunner)
+@InjectWith(Aadl2UiInjectorProvider)
+class Issue961Test extends OsateTest {
+	val static PROJECT_LOCATION = "org.osate.core.tests/models/issue961/"
+	val static FILE1 = "abstractprocess.aadl"
+	val static FILE2 = "package2.aadl"
+
+	@Test
+	def void test1() {
+		val pkg = getPackage(FILE1, PROJECT_LOCATION + FILE1)
+		
+		val instance1 = getSystemInstance(pkg, "s.i", "s_i_Instance")
+		testSubComponentCategory(instance1, "p", ComponentCategory.PROCESS)
+		testSubComponentCategory(instance1, "b", ComponentCategory.BUS)
+		
+		val instance2 = getSystemInstance(pkg, "s.j", "s_j_Instance")
+		testSubComponentCategory(instance2, "x", ComponentCategory.ABSTRACT)
+		
+		val instance3 = getSystemInstance(pkg, "s.k", "s_k_Instance")
+		testSubComponentCategory(instance3, "x", ComponentCategory.PROCESS)
+	}
+
+	@Test
+	def void test2() {
+		val pkg = getPackage(FILE2, PROJECT_LOCATION + FILE2)
+
+		val instance = getSystemInstance(pkg, "SSS.i", "SSS_i_Instance")		
+		testSubSubComponentCategory(instance, "sub1", "s1", ComponentCategory.BUS)
+		testSubSubComponentCategory(instance, "sub2", "s1", ComponentCategory.PROCESS)
+	}
+	
+	private def AadlPackage getPackage(String fname, String path) {
+		createFiles(fname -> readFile(path))
+		ignoreSerializationDifferences
+		testFile(fname).resource.contents.head as AadlPackage
+	}
+	
+	private def static SystemInstance getSystemInstance(
+		AadlPackage pkg, String systemImplName, String expectedInstanceName
+	) {
+		val cls = pkg.ownedPublicSection.ownedClassifiers
+		assertTrue('System implementation "' + systemImplName + '" not found', cls.exists[name == systemImplName])
+		
+		// Instantiate system
+		val sysImpl = cls.findFirst[name == systemImplName] as SystemImplementation
+		val instance = InstantiateModel::buildInstanceModelFile(sysImpl)
+		assertEquals(expectedInstanceName, instance.name)
+		return instance
+		
+	}
+	
+	private def static testSubComponentCategory(
+		SystemInstance instance, String subName, ComponentCategory expectedCategory
+	) {
+		val sub = instance.componentInstances.findFirst[name == subName]
+		val subCat = sub.category;
+		assertTrue(subName + ' has category ' + subCat + '; expected "' + expectedCategory.getName + '"', subCat == expectedCategory)
+	}
+	
+	private def static testSubSubComponentCategory(
+		SystemInstance instance, String sub1Name, String sub2Name, ComponentCategory expectedCategory
+	) {
+		val sub = instance.componentInstances.findFirst[name == sub1Name]
+		val subSub = sub.componentInstances.findFirst[name == sub2Name]
+		val subSubCat = subSub.category;
+		assertTrue(sub1Name + '.' + sub2Name + ' has category ' + subSubCat + '; expected "' + expectedCategory.getName + '"', subSubCat == expectedCategory)
+	}
+}


### PR DESCRIPTION
I think the category can be determined as follows:

If the classifier is not abstract then use its category (and maybe check
that the subcomponent either has the same category or is abstract).
If the classifier is abstract then use the category from the
subcomponent.

Only if both are abstract the component instance should be abstract.
If both are not abstract then they must have the same category. If the
categories are different, validation should already have reported an
error, and we don't instantiate models with errors. It can't hurt if the
instantiator checks again, though.