### PR TITLE
Update ARINC653 property set and examples for newer annex property set

### DIFF
--- a/org.osate.contribution.sei/resources/properties/ARINC653.aadl
+++ b/org.osate.contribution.sei/resources/properties/ARINC653.aadl
@@ -13,11 +13,11 @@ Sampling_Refresh_Period : Time applies to ( data port );
 --be extended by a given implementation.
 Supported_Error_Code: type enumeration (Module_Config, Module_Init, Module_Scheduling, Partition_Scheduling, Partition_Config, Partition_Handler, Partition_Init, Deadline_Miss, Application_Error, Numeric_Error, Illegal_Request, Stack_Overflow, Memory_Violation, Hardware_Fault, Power_Fail);
 
---The Supported_Memory_Type enumeration describes possible content of an AADL memory component.
-Supported_Memory_Type : type enumeration (Data_Memory, Code_Memory, IO_Memory);
+--The Supported_Memory_Kind enumeration describes possible content of an AADL memory component.
+Supported_Memory_Kind : type enumeration (Memory_Data, Memory_Code);
 
---The Memory_Type property describes the content of an AADL memory component.
-Memory_Type : list of ARINC653::Supported_Memory_Type applies to ( memory );
+--The Memory_Kind property describes the content of an AADL memory component.
+Memory_Kind : list of ARINC653::Supported_Memory_Kind applies to ( memory );
 
 --The Timeout property specifies the timeout used by an ARINC653 process when sending/receiving a
 --data. Depending on which component is used, the property value could be useful for sender or receiver side.
@@ -29,7 +29,7 @@ Supported_DAL_Type : type enumeration (LEVEL_A, LEVEL_B, LEVEL_C, LEVEL_D, LEVEL
 
 --The Criticality property defines the Design Assurance Level of a partition. It is associated to the
 --runtime of each partition (an AADL virtual processor component).
-DAL : ARINC653::Supported_DAL_Type applies to (virtual processor, system, abstract);
+DAL : ARINC653::Supported_DAL_Type applies to (virtual processor, process, thread, subprogram);
 
 --Module version description.
 Module_Version : aadlstring applies to (processor);

--- a/org.osate.ui/examples/ARINC653/arinc.aadl
+++ b/org.osate.ui/examples/ARINC653/arinc.aadl
@@ -80,8 +80,8 @@ public
 
 	memory segment
 		properties
-			ARINC653::Memory_Type => (Data_Memory, Code_Memory);
-			Byte_Count => 1000;
+			ARINC653::Memory_Kind => (Memory_Data, Memory_Code);
+			Memory_Size => 1000 Bytes;
 	end segment;
 
 	memory implementation segment.i

--- a/org.osate.ui/examples/ARINC653/arincexample1.aadl
+++ b/org.osate.ui/examples/ARINC653/arincexample1.aadl
@@ -186,13 +186,13 @@ public
 	memory partition1_memory
 		properties
 			Base_Address => 0;
-			ARINC653::Memory_Type => (Code_Memory);
+			ARINC653::Memory_Kind => (Memory_Code);
 	end partition1_memory;
 
 	memory partition2_memory
 		properties
 			Base_Address => 100;
-			ARINC653::Memory_Type => (Code_Memory);
+			ARINC653::Memory_Kind => (Memory_Code);
 	end partition2_memory;
 
 	memory main_memory


### PR DESCRIPTION
This fixes #847 and makes the built in ARINC653 property set and examples consistent with how the property set is defined in the newer ARINC653 annex instead of the deprecated annex.