### PR TITLE
1021 ise with subprogram calls

### DIFF
--- a/org.osate.aadl2/src/org/osate/aadl2/operations/BehavioredImplementationOperations.java
+++ b/org.osate.aadl2/src/org/osate/aadl2/operations/BehavioredImplementationOperations.java
@@ -78,7 +78,15 @@ public class BehavioredImplementationOperations extends ComponentImplementationO
 	 */
 	public static EList<SubprogramCall> subprogramCalls(BehavioredImplementation behavioredImplementation) {
 		EList<SubprogramCall> allCalls = new EObjectEList<SubprogramCall>(SubprogramCall.class,
-				(InternalEObject) behavioredImplementation, Aadl2Package.BEHAVIORED_IMPLEMENTATION__SUBPROGRAM_CALL);
+				(InternalEObject) behavioredImplementation, Aadl2Package.BEHAVIORED_IMPLEMENTATION__SUBPROGRAM_CALL) {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			protected boolean isNotificationRequired() {
+				return false;
+			}
+		};
+
 		for (SubprogramCallSequence callSequence : behavioredImplementation.getOwnedSubprogramCallSequences()) {
 			allCalls.addAll(callSequence.getOwnedSubprogramCalls());
 		}

--- a/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/serializing/Aadl2TransientValueService.java
+++ b/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/serializing/Aadl2TransientValueService.java
@@ -50,6 +50,7 @@ public class Aadl2TransientValueService extends DefaultTransientValueService {
 				|| feature == Aadl2Package.eINSTANCE.getElement_OwnedComment()
 				|| feature == Aadl2Package.eINSTANCE.getDefaultAnnexLibrary_ParsedAnnexLibrary()
 				|| feature == Aadl2Package.eINSTANCE.getDefaultAnnexSubclause_ParsedAnnexSubclause()
+				|| feature == Aadl2Package.eINSTANCE.getBehavioredImplementation_SubprogramCall()
 				|| (owner instanceof ModalPath && feature == Aadl2Package.eINSTANCE.getModalElement_InMode())
 				|| (owner instanceof Subcomponent && feature == Aadl2Package.eINSTANCE.getModalElement_InMode())) {
 			return true;


### PR DESCRIPTION
fixes #1021 
@philip-alldredge This fixes the IllegalStateException with the example AADL project when adding a subcomponent. For good measure, I've also declared the structural feature as transient for the serializer.