### PR TITLE
Trim leading spaces from the beginning of the serialized text.

### DIFF
--- a/org.osate.annexsupport/src/org/osate/annexsupport/AnnexUnparserProxy.java
+++ b/org.osate.annexsupport/src/org/osate/annexsupport/AnnexUnparserProxy.java
@@ -66,7 +66,7 @@ public class AnnexUnparserProxy extends AnnexProxy implements AnnexUnparser {
 		if (unparser == null) {
 			return "";
 		}
-		return unparser.unparseAnnexLibrary(library, indent);
+		return unparser.unparseAnnexLibrary(library, indent).replaceAll("^ +", "");
 	}
 
 	/*
@@ -82,7 +82,7 @@ public class AnnexUnparserProxy extends AnnexProxy implements AnnexUnparser {
 		if (unparser == null) {
 			return "";
 		}
-		return unparser.unparseAnnexSubclause(subclause, indent);
+		return unparser.unparseAnnexSubclause(subclause, indent).replaceAll("^ +", "");
 	}
 
 	private AnnexUnparser getUnparser() {


### PR DESCRIPTION
This only trims spaces, not all whitespace. Newlines and tabs are
preserved. Fixes #1074.